### PR TITLE
Add Elaine Knight as an editor of the HTTP response code reliability document.

### DIFF
--- a/response-code-reliability.bs
+++ b/response-code-reliability.bs
@@ -80,9 +80,3 @@ This registration will be submitted to the IESG for review, approval, and regist
 
 : Related information:
 :: None.
-
-<h2 id="acknowedgements" class="no-num">Acknowledgements</h2>
-
-Many thanks to
-Elaine Knight
-for their valuable feedback on this proposal.

--- a/response-code-reliability.bs
+++ b/response-code-reliability.bs
@@ -6,6 +6,7 @@ Status: ED
 Group: WebAppSec
 Repository: w3c/webappsec-change-password-url
 URL: https://w3c.github.io/webappsec-change-password-url/response-code-reliability.html
+Editor: Elaine Knight, w3cid 126366, Apple Inc. https://apple.com, elaine_knight@apple.com
 Editor: Ricky Mondello, w3cid 103933, Apple Inc. https://apple.com/, rmondello@apple.com
 Editor: Theresa O'Connor, w3cid 40614, Apple Inc. https://apple.com/, hober@apple.com
 Abstract: Defines a method for detecting the reliability of an HTTP server's response status codes.


### PR DESCRIPTION
@ItsElaineTime is the engineer who came up with this technique.

Per W3C Process, chairs appoint editors, so I've requested reviews from @mikewest & @dveditz.