### PR TITLE
Add 1Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Specification complexity. If we determine we need other account management well-
 
 * iCloud Keychain on iOS 12
 * Safari 12
+* 1Password (1Password 8 and 1Password for Chrome, Firefox, Edge and macOS Safari)
 
 ### What about servers whose HTTP response codes are unreliable?
 


### PR DESCRIPTION
At 1Password, we've shipped support for this across all of our 1Password 8 clients, including [our extension](https://twitter.com/oliverdunk_/status/1446155646554968064?s=20&t=c0nWLdN064z6xbPaE1spyw) and [other apps](https://twitter.com/roustem/status/1490381773913661442?s=20&t=c0nWLdN064z6xbPaE1spyw). We'd love to be listed in the README as a tool that has adopted the specification.